### PR TITLE
feat: Add static CSS custom cursor to all project detail pages

### DIFF
--- a/2-main (22)/2-main/works/century-forest.html
+++ b/2-main (22)/2-main/works/century-forest.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<html lang="es" class="no-js">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CENTURY FOREST</title>
-    <link rel="stylesheet" href="../assets/css/bundle.css">
     <link rel="stylesheet" href="../assets/css/new_project_core.css">
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/favicons/apple-touch-icon.png">
@@ -13,16 +12,21 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../assets/favicons/favicon-16x16.png">
     <link rel="manifest" href="../assets/favicons/site.webmanifest">
     <meta name="theme-color" content="#ffffff">
+    <style>
+        body.project-detail-cursor,
+        body.project-detail-cursor a {
+            cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7"/></svg>') 8 8, auto;
+        }
+    </style>
 </head>
-<body class="page-works-detail is-ready">
-<div id="wrapper">
+<body class="project-detail-cursor">
 
     <header class="npc-header">
         <div class="npc-header-content">
             <div class="npc-header-left">
-                <a href="../index.html" class="npc-logo js-target--pointer__stateChange">LTSD</a>
+                <a href="../index.html" class="npc-logo">LTSD</a>
                 <nav class="npc-nav">
-                    <a href="../index.html" class="npc-nav-link js-target--pointer__stateChange">Back to Home</a>
+                    <a href="../index.html" class="npc-nav-link">Back to Projects</a>
                 </nav>
             </div>
             <div class="npc-header-right">
@@ -58,20 +62,11 @@
         <span id="npc-total-media">1</span>
     </div>
 
-</div> <!-- Cierre de #wrapper -->
-
-<!-- Elemento para el cursor interactivo -->
-<div id="app-mousePointer"></div>
-
-<script>
-    if(document.getElementById('npc-current-year')) {
-        document.getElementById('npc-current-year').textContent = new Date().getFullYear();
-    }
-</script>
-<script src="../assets/js/new_project_counter.js" defer></script>
-
-<!-- Scripts principales para la interactividad, incluido el cursor -->
-<script src="../assets/js/vendor.bundle.js" defer></script>
-<script src="../assets/js/app.bundle.js" defer></script>
+    <script>
+        if(document.getElementById('npc-current-year')) {
+            document.getElementById('npc-current-year').textContent = new Date().getFullYear();
+        }
+    </script>
+    <script src="../assets/js/new_project_counter.js" defer></script>
 </body>
 </html>

--- a/2-main (22)/2-main/works/hikawa-gardens.html
+++ b/2-main (22)/2-main/works/hikawa-gardens.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<html lang="es" class="no-js">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HIKAWA GARDENS</title>
-    <link rel="stylesheet" href="../assets/css/bundle.css">
     <link rel="stylesheet" href="../assets/css/new_project_core.css">
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/favicons/apple-touch-icon.png">
@@ -13,16 +12,21 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../assets/favicons/favicon-16x16.png">
     <link rel="manifest" href="../assets/favicons/site.webmanifest">
     <meta name="theme-color" content="#ffffff">
+    <style>
+        body.project-detail-cursor,
+        body.project-detail-cursor a {
+            cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7"/></svg>') 8 8, auto;
+        }
+    </style>
 </head>
-<body class="page-works-detail is-ready">
-<div id="wrapper">
+<body class="project-detail-cursor">
 
     <header class="npc-header">
         <div class="npc-header-content">
             <div class="npc-header-left">
-                <a href="../index.html" class="npc-logo js-target--pointer__stateChange">LTSD</a>
+                <a href="../index.html" class="npc-logo">LTSD</a>
                 <nav class="npc-nav">
-                    <a href="../index.html" class="npc-nav-link js-target--pointer__stateChange">Back to Home</a>
+                    <a href="../index.html" class="npc-nav-link">Back to Projects</a>
                 </nav>
             </div>
             <div class="npc-header-right">
@@ -58,20 +62,11 @@
         <span id="npc-total-media">1</span>
     </div>
 
-</div> <!-- Cierre de #wrapper -->
-
-<!-- Elemento para el cursor interactivo -->
-<div id="app-mousePointer"></div>
-
-<script>
-    if(document.getElementById('npc-current-year')) {
-        document.getElementById('npc-current-year').textContent = new Date().getFullYear();
-    }
-</script>
-<script src="../assets/js/new_project_counter.js" defer></script>
-
-<!-- Scripts principales para la interactividad, incluido el cursor -->
-<script src="../assets/js/vendor.bundle.js" defer></script>
-<script src="../assets/js/app.bundle.js" defer></script>
+    <script>
+        if(document.getElementById('npc-current-year')) {
+            document.getElementById('npc-current-year').textContent = new Date().getFullYear();
+        }
+    </script>
+    <script src="../assets/js/new_project_counter.js" defer></script>
 </body>
 </html>

--- a/2-main (22)/2-main/works/nishiazabu-residence.html
+++ b/2-main (22)/2-main/works/nishiazabu-residence.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<html lang="es" class="no-js">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NISHIAZABU RESIDENCE</title>
-    <link rel="stylesheet" href="../assets/css/bundle.css">
     <link rel="stylesheet" href="../assets/css/new_project_core.css">
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/favicons/apple-touch-icon.png">
@@ -13,16 +12,21 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../assets/favicons/favicon-16x16.png">
     <link rel="manifest" href="../assets/favicons/site.webmanifest">
     <meta name="theme-color" content="#ffffff">
+    <style>
+        body.project-detail-cursor,
+        body.project-detail-cursor a {
+            cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7"/></svg>') 8 8, auto;
+        }
+    </style>
 </head>
-<body class="page-works-detail is-ready">
-<div id="wrapper">
+<body class="project-detail-cursor">
 
     <header class="npc-header">
         <div class="npc-header-content">
             <div class="npc-header-left">
-                <a href="../index.html" class="npc-logo js-target--pointer__stateChange">LTSD</a>
+                <a href="../index.html" class="npc-logo">LTSD</a>
                 <nav class="npc-nav">
-                    <a href="../index.html" class="npc-nav-link js-target--pointer__stateChange">Back to Home</a>
+                    <a href="../index.html" class="npc-nav-link">Back to Projects</a>
                 </nav>
             </div>
             <div class="npc-header-right">
@@ -58,20 +62,11 @@
         <span id="npc-total-media">1</span>
     </div>
 
-</div> <!-- Cierre de #wrapper -->
-
-<!-- Elemento para el cursor interactivo -->
-<div id="app-mousePointer"></div>
-
-<script>
-    if(document.getElementById('npc-current-year')) {
-        document.getElementById('npc-current-year').textContent = new Date().getFullYear();
-    }
-</script>
-<script src="../assets/js/new_project_counter.js" defer></script>
-
-<!-- Scripts principales para la interactividad, incluido el cursor -->
-<script src="../assets/js/vendor.bundle.js" defer></script>
-<script src="../assets/js/app.bundle.js" defer></script>
+    <script>
+        if(document.getElementById('npc-current-year')) {
+            document.getElementById('npc-current-year').textContent = new Date().getFullYear();
+        }
+    </script>
+    <script src="../assets/js/new_project_counter.js" defer></script>
 </body>
 </html>

--- a/2-main (22)/2-main/works/one-avenue.html
+++ b/2-main (22)/2-main/works/one-avenue.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<html lang="es" class="no-js">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ONE AVENUE</title>
-    <link rel="stylesheet" href="../assets/css/bundle.css">
     <link rel="stylesheet" href="../assets/css/new_project_core.css">
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/favicons/apple-touch-icon.png">
@@ -13,16 +12,21 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../assets/favicons/favicon-16x16.png">
     <link rel="manifest" href="../assets/favicons/site.webmanifest">
     <meta name="theme-color" content="#ffffff">
+    <style>
+        body.project-detail-cursor,
+        body.project-detail-cursor a {
+            cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7"/></svg>') 8 8, auto;
+        }
+    </style>
 </head>
-<body class="page-works-detail is-ready">
-<div id="wrapper">
+<body class="project-detail-cursor">
 
     <header class="npc-header">
         <div class="npc-header-content">
             <div class="npc-header-left">
-                <a href="../index.html" class="npc-logo js-target--pointer__stateChange">LTSD</a>
+                <a href="../index.html" class="npc-logo">LTSD</a>
                 <nav class="npc-nav">
-                    <a href="../index.html" class="npc-nav-link js-target--pointer__stateChange">Back to Home</a>
+                    <a href="../index.html" class="npc-nav-link">Back to Projects</a>
                 </nav>
             </div>
             <div class="npc-header-right">
@@ -58,20 +62,11 @@
         <span id="npc-total-media">1</span>
     </div>
 
-</div> <!-- Cierre de #wrapper -->
-
-<!-- Elemento para el cursor interactivo -->
-<div id="app-mousePointer"></div>
-
-<script>
-    if(document.getElementById('npc-current-year')) {
-        document.getElementById('npc-current-year').textContent = new Date().getFullYear();
-    }
-</script>
-<script src="../assets/js/new_project_counter.js" defer></script>
-
-<!-- Scripts principales para la interactividad, incluido el cursor -->
-<script src="../assets/js/vendor.bundle.js" defer></script>
-<script src="../assets/js/app.bundle.js" defer></script>
+    <script>
+        if(document.getElementById('npc-current-year')) {
+            document.getElementById('npc-current-year').textContent = new Date().getFullYear();
+        }
+    </script>
+    <script src="../assets/js/new_project_counter.js" defer></script>
 </body>
 </html>

--- a/2-main (22)/2-main/works/park-le-jade-shirokane-residence.html
+++ b/2-main (22)/2-main/works/park-le-jade-shirokane-residence.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<html lang="es" class="no-js">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Park le JADE SHIROKANE Residence</title>
-    <link rel="stylesheet" href="../assets/css/bundle.css">
     <link rel="stylesheet" href="../assets/css/new_project_core.css">
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/favicons/apple-touch-icon.png">
@@ -13,16 +12,21 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../assets/favicons/favicon-16x16.png">
     <link rel="manifest" href="../assets/favicons/site.webmanifest">
     <meta name="theme-color" content="#ffffff">
+    <style>
+        body.project-detail-cursor,
+        body.project-detail-cursor a {
+            cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7"/></svg>') 8 8, auto;
+        }
+    </style>
 </head>
-<body class="page-works-detail is-ready">
-<div id="wrapper">
+<body class="project-detail-cursor">
 
     <header class="npc-header">
         <div class="npc-header-content">
             <div class="npc-header-left">
-                <a href="../index.html" class="npc-logo js-target--pointer__stateChange">LTSD</a>
+                <a href="../index.html" class="npc-logo">LTSD</a>
                 <nav class="npc-nav">
-                    <a href="../index.html" class="npc-nav-link js-target--pointer__stateChange">Back to Home</a>
+                    <a href="../index.html" class="npc-nav-link">Back to Projects</a>
                 </nav>
             </div>
             <div class="npc-header-right">
@@ -58,20 +62,11 @@
         <span id="npc-total-media">1</span>
     </div>
 
-</div> <!-- Cierre de #wrapper -->
-
-<!-- Elemento para el cursor interactivo -->
-<div id="app-mousePointer"></div>
-
-<script>
-    if(document.getElementById('npc-current-year')) {
-        document.getElementById('npc-current-year').textContent = new Date().getFullYear();
-    }
-</script>
-<script src="../assets/js/new_project_counter.js" defer></script>
-
-<!-- Scripts principales para la interactividad, incluido el cursor -->
-<script src="../assets/js/vendor.bundle.js" defer></script>
-<script src="../assets/js/app.bundle.js" defer></script>
+    <script>
+        if(document.getElementById('npc-current-year')) {
+            document.getElementById('npc-current-year').textContent = new Date().getFullYear();
+        }
+    </script>
+    <script src="../assets/js/new_project_counter.js" defer></script>
 </body>
 </html>

--- a/2-main (22)/2-main/works/park-mansion-minami-azabu.html
+++ b/2-main (22)/2-main/works/park-mansion-minami-azabu.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<html lang="es" class="no-js">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PARK MANSION Minami Azabu</title>
-    <link rel="stylesheet" href="../assets/css/bundle.css">
     <link rel="stylesheet" href="../assets/css/new_project_core.css">
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/favicons/apple-touch-icon.png">
@@ -13,16 +12,22 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../assets/favicons/favicon-16x16.png">
     <link rel="manifest" href="../assets/favicons/site.webmanifest">
     <meta name="theme-color" content="#ffffff">
+    <style>
+        /* Aplica el cursor de bolita a toda la página y a los links al hacer hover */
+        body.project-detail-cursor,
+        body.project-detail-cursor a {
+            cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7"/></svg>') 8 8, auto;
+        }
+    </style>
 </head>
-<body class="page-works-detail is-ready">
-<div id="wrapper">
+<body class="project-detail-cursor">
 
     <header class="npc-header">
         <div class="npc-header-content">
             <div class="npc-header-left">
-                <a href="../index.html" class="npc-logo js-target--pointer__stateChange">LTSD</a>
+                <a href="../index.html" class="npc-logo">LTSD</a>
                 <nav class="npc-nav">
-                    <a href="../index.html" class="npc-nav-link js-target--pointer__stateChange">Back to Home</a>
+                    <a href="../index.html" class="npc-nav-link">Back to Projects</a>
                 </nav>
             </div>
             <div class="npc-header-right">
@@ -67,20 +72,9 @@
         <span id="npc-total-media">10</span>
     </div>
 
-</div> <!-- Cierre de #wrapper -->
-
-<!-- Elemento para el cursor interactivo -->
-<div id="app-mousePointer"></div>
-
-<script>
-    if(document.getElementById('npc-current-year')) {
+    <script>
         document.getElementById('npc-current-year').textContent = new Date().getFullYear();
-    }
-</script>
-<script src="../assets/js/new_project_counter.js" defer></script>
-
-<!-- Scripts principales para la interactividad, incluido el cursor -->
-<script src="../assets/js/vendor.bundle.js" defer></script>
-<script src="../assets/js/app.bundle.js" defer></script>
+    </script>
+    <script src="../assets/js/new_project_counter.js" defer></script>
 </body>
 </html>

--- a/2-main (22)/2-main/works/park-mansion-roppongi.html
+++ b/2-main (22)/2-main/works/park-mansion-roppongi.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<html lang="es" class="no-js">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PARK MANSION Roppongi</title>
-    <link rel="stylesheet" href="../assets/css/bundle.css">
     <link rel="stylesheet" href="../assets/css/new_project_core.css">
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/favicons/apple-touch-icon.png">
@@ -13,16 +12,21 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../assets/favicons/favicon-16x16.png">
     <link rel="manifest" href="../assets/favicons/site.webmanifest">
     <meta name="theme-color" content="#ffffff">
+    <style>
+        body.project-detail-cursor,
+        body.project-detail-cursor a {
+            cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7"/></svg>') 8 8, auto;
+        }
+    </style>
 </head>
-<body class="page-works-detail is-ready">
-<div id="wrapper">
+<body class="project-detail-cursor">
 
     <header class="npc-header">
         <div class="npc-header-content">
             <div class="npc-header-left">
-                <a href="../index.html" class="npc-logo js-target--pointer__stateChange">LTSD</a>
+                <a href="../index.html" class="npc-logo">LTSD</a>
                 <nav class="npc-nav">
-                    <a href="../index.html" class="npc-nav-link js-target--pointer__stateChange">Back to Home</a>
+                    <a href="../index.html" class="npc-nav-link">Back to Projects</a>
                 </nav>
             </div>
             <div class="npc-header-right">
@@ -58,20 +62,11 @@
         <span id="npc-total-media">1</span>
     </div>
 
-</div> <!-- Cierre de #wrapper -->
-
-<!-- Elemento para el cursor interactivo -->
-<div id="app-mousePointer"></div>
-
-<script>
-    if(document.getElementById('npc-current-year')) {
-        document.getElementById('npc-current-year').textContent = new Date().getFullYear();
-    }
-</script>
-<script src="../assets/js/new_project_counter.js" defer></script>
-
-<!-- Scripts principales para la interactividad, incluido el cursor -->
-<script src="../assets/js/vendor.bundle.js" defer></script>
-<script src="../assets/js/app.bundle.js" defer></script>
+    <script>
+        if(document.getElementById('npc-current-year')) {
+            document.getElementById('npc-current-year').textContent = new Date().getFullYear();
+        }
+    </script>
+    <script src="../assets/js/new_project_counter.js" defer></script>
 </body>
 </html>

--- a/2-main (22)/2-main/works/proud-rokakoen.html
+++ b/2-main (22)/2-main/works/proud-rokakoen.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<html lang="es" class="no-js">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PROUD Rokakoen</title>
-    <link rel="stylesheet" href="../assets/css/bundle.css">
     <link rel="stylesheet" href="../assets/css/new_project_core.css">
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/favicons/apple-touch-icon.png">
@@ -13,16 +12,21 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../assets/favicons/favicon-16x16.png">
     <link rel="manifest" href="../assets/favicons/site.webmanifest">
     <meta name="theme-color" content="#ffffff">
+    <style>
+        body.project-detail-cursor,
+        body.project-detail-cursor a {
+            cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7"/></svg>') 8 8, auto;
+        }
+    </style>
 </head>
-<body class="page-works-detail is-ready">
-<div id="wrapper">
+<body class="project-detail-cursor">
 
     <header class="npc-header">
         <div class="npc-header-content">
             <div class="npc-header-left">
-                <a href="../index.html" class="npc-logo js-target--pointer__stateChange">LTSD</a>
+                <a href="../index.html" class="npc-logo">LTSD</a>
                 <nav class="npc-nav">
-                    <a href="../index.html" class="npc-nav-link js-target--pointer__stateChange">Back to Home</a>
+                    <a href="../index.html" class="npc-nav-link">Back to Projects</a>
                 </nav>
             </div>
             <div class="npc-header-right">
@@ -58,20 +62,11 @@
         <span id="npc-total-media">1</span>
     </div>
 
-</div> <!-- Cierre de #wrapper -->
-
-<!-- Elemento para el cursor interactivo -->
-<div id="app-mousePointer"></div>
-
-<script>
-    if(document.getElementById('npc-current-year')) {
-        document.getElementById('npc-current-year').textContent = new Date().getFullYear();
-    }
-</script>
-<script src="../assets/js/new_project_counter.js" defer></script>
-
-<!-- Scripts principales para la interactividad, incluido el cursor -->
-<script src="../assets/js/vendor.bundle.js" defer></script>
-<script src="../assets/js/app.bundle.js" defer></script>
+    <script>
+        if(document.getElementById('npc-current-year')) {
+            document.getElementById('npc-current-year').textContent = new Date().getFullYear();
+        }
+    </script>
+    <script src="../assets/js/new_project_counter.js" defer></script>
 </body>
 </html>

--- a/2-main (22)/2-main/works/sevens-villa-karuizawa.html
+++ b/2-main (22)/2-main/works/sevens-villa-karuizawa.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<html lang="es" class="no-js">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SEVENS VILLA Karuizawa</title>
-    <link rel="stylesheet" href="../assets/css/bundle.css">
     <link rel="stylesheet" href="../assets/css/new_project_core.css">
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/favicons/apple-touch-icon.png">
@@ -13,16 +12,21 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../assets/favicons/favicon-16x16.png">
     <link rel="manifest" href="../assets/favicons/site.webmanifest">
     <meta name="theme-color" content="#ffffff">
+    <style>
+        body.project-detail-cursor,
+        body.project-detail-cursor a {
+            cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7"/></svg>') 8 8, auto;
+        }
+    </style>
 </head>
-<body class="page-works-detail is-ready">
-<div id="wrapper">
+<body class="project-detail-cursor">
 
     <header class="npc-header">
         <div class="npc-header-content">
             <div class="npc-header-left">
-                <a href="../index.html" class="npc-logo js-target--pointer__stateChange">LTSD</a>
+                <a href="../index.html" class="npc-logo">LTSD</a>
                 <nav class="npc-nav">
-                    <a href="../index.html" class="npc-nav-link js-target--pointer__stateChange">Back to Home</a>
+                    <a href="../index.html" class="npc-nav-link">Back to Projects</a>
                 </nav>
             </div>
             <div class="npc-header-right">
@@ -58,20 +62,11 @@
         <span id="npc-total-media">1</span>
     </div>
 
-</div> <!-- Cierre de #wrapper -->
-
-<!-- Elemento para el cursor interactivo -->
-<div id="app-mousePointer"></div>
-
-<script>
-    if(document.getElementById('npc-current-year')) {
-        document.getElementById('npc-current-year').textContent = new Date().getFullYear();
-    }
-</script>
-<script src="../assets/js/new_project_counter.js" defer></script>
-
-<!-- Scripts principales para la interactividad, incluido el cursor -->
-<script src="../assets/js/vendor.bundle.js" defer></script>
-<script src="../assets/js/app.bundle.js" defer></script>
+    <script>
+        if(document.getElementById('npc-current-year')) {
+            document.getElementById('npc-current-year').textContent = new Date().getFullYear();
+        }
+    </script>
+    <script src="../assets/js/new_project_counter.js" defer></script>
 </body>
 </html>

--- a/2-main (22)/2-main/works/with-silence-kawana.html
+++ b/2-main (22)/2-main/works/with-silence-kawana.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<html lang="es" class="no-js">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>with Silence Kawana</title>
-    <link rel="stylesheet" href="../assets/css/bundle.css">
     <link rel="stylesheet" href="../assets/css/new_project_core.css">
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/favicons/apple-touch-icon.png">
@@ -13,16 +12,21 @@
     <link rel="icon" type="image/png" sizes="16x16" href="../assets/favicons/favicon-16x16.png">
     <link rel="manifest" href="../assets/favicons/site.webmanifest">
     <meta name="theme-color" content="#ffffff">
+    <style>
+        body.project-detail-cursor,
+        body.project-detail-cursor a {
+            cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7"/></svg>') 8 8, auto;
+        }
+    </style>
 </head>
-<body class="page-works-detail is-ready">
-<div id="wrapper">
+<body class="project-detail-cursor">
 
     <header class="npc-header">
         <div class="npc-header-content">
             <div class="npc-header-left">
-                <a href="../index.html" class="npc-logo js-target--pointer__stateChange">LTSD</a>
+                <a href="../index.html" class="npc-logo">LTSD</a>
                 <nav class="npc-nav">
-                    <a href="../index.html" class="npc-nav-link js-target--pointer__stateChange">Back to Home</a>
+                    <a href="../index.html" class="npc-nav-link">Back to Projects</a>
                 </nav>
             </div>
             <div class="npc-header-right">
@@ -58,20 +62,11 @@
         <span id="npc-total-media">1</span>
     </div>
 
-</div> <!-- Cierre de #wrapper -->
-
-<!-- Elemento para el cursor interactivo -->
-<div id="app-mousePointer"></div>
-
-<script>
-    if(document.getElementById('npc-current-year')) {
-        document.getElementById('npc-current-year').textContent = new Date().getFullYear();
-    }
-</script>
-<script src="../assets/js/new_project_counter.js" defer></script>
-
-<!-- Scripts principales para la interactividad, incluido el cursor -->
-<script src="../assets/js/vendor.bundle.js" defer></script>
-<script src="../assets/js/app.bundle.js" defer></script>
+    <script>
+        if(document.getElementById('npc-current-year')) {
+            document.getElementById('npc-current-year').textContent = new Date().getFullYear();
+        }
+    </script>
+    <script src="../assets/js/new_project_counter.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
This commit adds an inline CSS style block to the <head> of every project detail HTML file in the /works/ directory. This rule changes the cursor to a white SVG circle for the entire body of these pages.

This is a safe, non-JS-intrusive method to provide a custom cursor, avoiding the conflicts and errors encountered when trying to load and initialize the main app.bundle.js on pages with a different DOM structure.