### PR TITLE
feat: Implement water effect for page transitions

### DIFF
--- a/2-main (22)/2-main/assets/js/custom-transitions.js
+++ b/2-main (22)/2-main/assets/js/custom-transitions.js
@@ -1,16 +1,80 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const transitionLinks = document.querySelectorAll('a:not([href^="#"]):not([target="_blank"])');
+    let scene, camera, renderer, material, mesh;
 
+    function initWaterEffect() {
+        scene = new THREE.Scene();
+        camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+        renderer = new THREE.WebGLRenderer({ alpha: true });
+        renderer.setSize(window.innerWidth, window.innerHeight);
+        renderer.domElement.style.position = 'fixed';
+        renderer.domElement.style.top = '0';
+        renderer.domElement.style.left = '0';
+        renderer.domElement.style.zIndex = '9999';
+        renderer.domElement.style.display = 'none';
+        document.body.appendChild(renderer.domElement);
+
+        const geometry = new THREE.PlaneGeometry(2, 2);
+        material = new THREE.ShaderMaterial({
+            uniforms: {
+                time: { value: 1.0 },
+                resolution: { value: new THREE.Vector2(window.innerWidth, window.innerHeight) }
+            },
+            vertexShader: `
+                varying vec2 vUv;
+                void main() {
+                    vUv = uv;
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `,
+            fragmentShader: `
+                uniform vec2 resolution;
+                uniform float time;
+                varying vec2 vUv;
+
+                void main() {
+                    vec2 p = -1.0 + 2.0 * vUv;
+                    float a = time * 40.0;
+                    float d, e, f, g = 1.0 / 40.0, h, i, j, k, l, m;
+                    e = 400.0 * (p.x * 0.5 + 0.5);
+                    f = 400.0 * (p.y * 0.5 + 0.5);
+                    i = 200.0 + sin(e * g + a / 150.0) * 20.0;
+                    j = 200.0 + cos(f * g / 2.0 + a / 150.0) * 20.0;
+                    k = 200.0 + sin(f * g / 10.0 + a / 200.0) * 20.0;
+                    l = 200.0 + cos(e * g / 20.0 + a / 200.0) * 20.0;
+                    m = sin(i + j + k + l + a) * 0.5 + 0.5;
+                    gl_FragColor = vec4(m, m, m, 1.0);
+                }
+            `
+        });
+        mesh = new THREE.Mesh(geometry, material);
+        scene.add(mesh);
+
+        camera.position.z = 1;
+    }
+
+    function animateWater() {
+        if (renderer.domElement.style.display === 'none') return;
+        material.uniforms.time.value += 0.05;
+        renderer.render(scene, camera);
+        requestAnimationFrame(animateWater);
+    }
+
+    function showWaterEffect(callback) {
+        renderer.domElement.style.display = 'block';
+        animateWater();
+        setTimeout(callback, 1500); // Duration of the water effect
+    }
+
+    const transitionLinks = document.querySelectorAll('a:not([href^="#"]):not([target="_blank"])');
     transitionLinks.forEach(link => {
         link.addEventListener('click', function(event) {
             const url = this.href;
 
             if (url.startsWith(window.location.origin) && !this.closest('.p-stage__menu__item')) {
                 event.preventDefault();
-                document.body.classList.add('page-transition-out');
-                setTimeout(() => {
+                showWaterEffect(() => {
                     window.location.href = url;
-                }, 550);
+                });
             }
         });
     });
@@ -21,20 +85,20 @@ document.addEventListener('DOMContentLoaded', () => {
         if (targetUrl && !targetUrl.startsWith('http') && !targetUrl.startsWith('#')) {
             projectItemLi.addEventListener('click', function(event) {
                 event.preventDefault();
-                document.body.classList.add('page-transition-out');
-                setTimeout(() => {
+                showWaterEffect(() => {
                     window.location.href = targetUrl;
-                }, 550);
+                });
             });
         }
     });
 
     window.addEventListener('pageshow', (event) => {
         if (event.persisted) {
-            document.body.classList.remove('page-transition-out');
+            if (renderer && renderer.domElement) {
+                renderer.domElement.style.display = 'none';
+            }
         }
     });
 
-    // On page load, trigger the fade-in animation
-    document.body.classList.add('page-transition-in');
+    initWaterEffect();
 });

--- a/2-main (22)/2-main/water-effect.html
+++ b/2-main (22)/2-main/water-effect.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Water Effect Prototype</title>
+    <style>
+        body { margin: 0; }
+        canvas { display: block; }
+    </style>
+</head>
+<body>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script>
+        const scene = new THREE.Scene();
+        const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+        const renderer = new THREE.WebGLRenderer();
+        renderer.setSize(window.innerWidth, window.innerHeight);
+        document.body.appendChild(renderer.domElement);
+
+        const geometry = new THREE.PlaneGeometry(2, 2);
+        const material = new THREE.ShaderMaterial({
+            uniforms: {
+                time: { value: 1.0 },
+                resolution: { value: new THREE.Vector2(window.innerWidth, window.innerHeight) }
+            },
+            vertexShader: `
+                varying vec2 vUv;
+                void main() {
+                    vUv = uv;
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `,
+            fragmentShader: `
+                uniform vec2 resolution;
+                uniform float time;
+                varying vec2 vUv;
+
+                void main() {
+                    vec2 p = -1.0 + 2.0 * vUv;
+                    float a = time * 40.0;
+                    float d, e, f, g = 1.0 / 40.0, h, i, j, k, l, m;
+                    e = 400.0 * (p.x * 0.5 + 0.5);
+                    f = 400.0 * (p.y * 0.5 + 0.5);
+                    i = 200.0 + sin(e * g + a / 150.0) * 20.0;
+                    j = 200.0 + cos(f * g / 2.0 + a / 150.0) * 20.0;
+                    k = 200.0 + sin(f * g / 10.0 + a / 200.0) * 20.0;
+                    l = 200.0 + cos(e * g / 20.0 + a / 200.0) * 20.0;
+                    m = sin(i + j + k + l + a) * 0.5 + 0.5;
+                    gl_FragColor = vec4(m, m, m, 1.0);
+                }
+            `
+        });
+        const mesh = new THREE.Mesh(geometry, material);
+        scene.add(mesh);
+
+        camera.position.z = 1;
+
+        function animate() {
+            requestAnimationFrame(animate);
+            material.uniforms.time.value += 0.05;
+            renderer.render(scene, camera);
+        }
+        animate();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
- Add a realistic water flooding effect for page transitions using WebGL and three.js.
- Create a prototype for the water effect and integrate it into the page transition logic.
- Refine and test the transition for performance and visual quality.